### PR TITLE
windows build using angle (glesv2)

### DIFF
--- a/examples/gallery/main.cpp
+++ b/examples/gallery/main.cpp
@@ -4,6 +4,8 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
+
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;

--- a/examples/helloworld/main.cpp
+++ b/examples/helloworld/main.cpp
@@ -4,6 +4,8 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
+
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;

--- a/examples/mouse_events/main.cpp
+++ b/examples/mouse_events/main.cpp
@@ -4,6 +4,8 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
+
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;

--- a/examples/qnanopainter_vs_qpainter_demo/main.cpp
+++ b/examples/qnanopainter_vs_qpainter_demo/main.cpp
@@ -5,6 +5,8 @@
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
+
     QGuiApplication app(argc, argv);
 
     QQmlApplicationEngine engine;

--- a/examples/qnanopainter_vs_qpainter_demo/qnanopainter_vs_qpainter_demo.pro
+++ b/examples/qnanopainter_vs_qpainter_demo/qnanopainter_vs_qpainter_demo.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += qml quick
+QT += qml quick gui
 
 SOURCES += main.cpp \
     src/demoqpitem.cpp \

--- a/examples/qnanopainter_vs_qpainter_demo/qnanopainter_vs_qpainter_demo.pro
+++ b/examples/qnanopainter_vs_qpainter_demo/qnanopainter_vs_qpainter_demo.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 
-QT += qml quick gui
+QT += qml quick
 
 SOURCES += main.cpp \
     src/demoqpitem.cpp \

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.cpp
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.cpp
@@ -2,6 +2,7 @@
 #include "demoqnanoitem.h"
 #include <math.h>
 #include <QtMath>
+#include <QVarLengthArray>
 
 DemoQNanoItemPainter::DemoQNanoItemPainter()
     : m_animationTime(0.0)
@@ -79,8 +80,8 @@ void DemoQNanoItemPainter::paint(QNanoPainter *painter)
 
 void DemoQNanoItemPainter::drawGraphLine(float x, float y, float w, float h, int items, float t)
 {
-    float samples[items];
-    float sx[items], sy[items];
+    QVarLengthArray<float, 1024> samples(items);
+    QVarLengthArray<float, 1024> sx(items); QVarLengthArray<float, 1024> sy(items);
     float dx = w/(items-1);
     float dotSize = w/50;
     int i;
@@ -130,8 +131,9 @@ void DemoQNanoItemPainter::drawGraphLine(float x, float y, float w, float h, int
 }
 
 void DemoQNanoItemPainter::drawGraphBars(float x, float y, float w, float h, int items, float t) {
-    float samples[items];
-    float sx[items], sy[items];
+
+    QVarLengthArray<float, 1024> samples(items);
+    QVarLengthArray<float, 1024> sx(items); QVarLengthArray<float, 1024> sy(items);
     float dx = w/(items-1);
     float barWidth = dx * 0.8;
     float margin = dx - barWidth;
@@ -176,7 +178,7 @@ void DemoQNanoItemPainter::drawGraphCircles(float x, float y, float w, float h, 
 
     // Setup values
     qreal a1 = -pi/2;
-    qreal a0[items];
+    QVarLengthArray<qreal, 1024> a0(items);
     for (i=0; i<items; i++) {
         a0[i] = -pi/2 + pi2*(((float)items-i)/items)*showAnimationProgress;
     }

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqpitem.cpp
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqpitem.cpp
@@ -81,8 +81,8 @@ void DemoQPItem::paint(QPainter *painter)
 
 void DemoQPItem::drawGraphLine(float x, float y, float w, float h, int items, float t)
 {
-    float samples[items];
-    float sx[items], sy[items];
+    QVarLengthArray<float, 1024> samples(items);
+    QVarLengthArray<float, 1024> sx(items); QVarLengthArray<float, 1024> sy(items);
     float dx = w/(items-1);
     float dotSize = w/50;
     int i;
@@ -128,8 +128,8 @@ void DemoQPItem::drawGraphLine(float x, float y, float w, float h, int items, fl
 }
 
 void DemoQPItem::drawGraphBars(float x, float y, float w, float h, int items, float t) {
-    float samples[items];
-    float sx[items], sy[items];
+    QVarLengthArray<float, 1024> samples(items);
+    QVarLengthArray<float, 1024> sx(items); QVarLengthArray<float, 1024> sy(items);
     float dx = w/(items-1);
     float barWidth = dx * 0.8;
     float margin = dx - barWidth;
@@ -170,7 +170,7 @@ void DemoQPItem::drawGraphCircles(float x, float y, float w, float h, int items,
 
     // Setup values
     qreal a1 = 90*16;
-    qreal a0[items];
+    QVarLengthArray<qreal, 1024> a0(items);
     for (i=0; i<items; i++) {
         a0[i] = -360*16*(((float)items-i)/items)*showAnimationProgress;
     }

--- a/libqnanopainter/include.pri
+++ b/libqnanopainter/include.pri
@@ -6,9 +6,9 @@ INCLUDEPATH += $$PWD/
 CONFIG += c++11
 
 win32  {
-    LIBS += libglesv2.lib
-    DEFINES += QT_OPENGL_ES_2
+    QT_CONFIG += opengles2 angle
 }
+
 # Enable this to get drawind debug information
 #DEFINES += QNANO_DEBUG
 

--- a/libqnanopainter/include.pri
+++ b/libqnanopainter/include.pri
@@ -4,7 +4,10 @@ INCLUDEPATH += $$PWD/
 
 # Use c++11 features
 CONFIG += c++11
-
+win32  {
+    LIBS += libglesv2.lib
+    DEFINES += QT_OPENGL_ES_2
+}
 # Enable this to get drawind debug information
 #DEFINES += QNANO_DEBUG
 

--- a/libqnanopainter/include.pri
+++ b/libqnanopainter/include.pri
@@ -4,6 +4,7 @@ INCLUDEPATH += $$PWD/
 
 # Use c++11 features
 CONFIG += c++11
+
 win32  {
     LIBS += libglesv2.lib
     DEFINES += QT_OPENGL_ES_2

--- a/libqnanopainter/nanovg/nanovg.c
+++ b/libqnanopainter/nanovg/nanovg.c
@@ -2737,19 +2737,23 @@ void nvgFill(NVGcontext* ctx)
 					ctx->cache->bounds, ctx->cache->paths, ctx->cache->npaths);
 	
 #if DEBUG
-    // Count triangles
-    const NVGpath* path;
-    int i;
-    for (i = 0; i < ctx->cache->npaths; i++) {
-		path = &ctx->cache->paths[i];
-		int nfill = path->nfill-2;
-		if (nfill < 0) nfill = 0;
-		int nstroke = path->nstroke-2;
-		if (nstroke < 0) nstroke = 0;
-		ctx->fillTriCount += nfill;
-		ctx->fillTriCount += nstroke;
-		ctx->drawCallCount += 2;
-	}
+    {
+        // Count triangles
+        const NVGpath* path;
+        int i;
+        int nfill;
+        int nstroke;
+        for (i = 0; i < ctx->cache->npaths; i++) {
+            path = &ctx->cache->paths[i];
+            nfill = path->nfill-2;
+            if (nfill < 0) nfill = 0;
+            nstroke = path->nstroke-2;
+            if (nstroke < 0) nstroke = 0;
+            ctx->fillTriCount += nfill;
+            ctx->fillTriCount += nstroke;
+            ctx->drawCallCount += 2;
+        }
+    }
 #endif
 }
 
@@ -2805,14 +2809,16 @@ void nvgStroke(NVGcontext* ctx)
 					  strokeWidth, ctx->cache->paths, ctx->cache->npaths);
 
 #if DEBUG
-	// Count triangles
-    const NVGpath* path;
-    int i;
-    for (i = 0; i < ctx->cache->npaths; i++) {
-		path = &ctx->cache->paths[i];
-		ctx->strokeTriCount += path->nstroke-2;
-		ctx->drawCallCount++;
-	}
+    {
+        // Count triangles
+        const NVGpath* path;
+        int i;
+        for (i = 0; i < ctx->cache->npaths; i++) {
+            path = &ctx->cache->paths[i];
+            ctx->strokeTriCount += path->nstroke-2;
+            ctx->drawCallCount++;
+        }
+    }
 #endif
 }
 

--- a/libqnanopainter/private/qnanodataelement.h
+++ b/libqnanopainter/private/qnanodataelement.h
@@ -24,7 +24,6 @@
 
 struct QNanoDataElement
 {
-    unsigned char* data;
     int id;
     int width;
     int height;

--- a/libqnanopainter/qnanoimage.cpp
+++ b/libqnanopainter/qnanoimage.cpp
@@ -66,7 +66,7 @@ int QNanoImage::getID(NVGcontext* nvg)
 
     if (dataCache->contains(m_filename)) {
         // Image is in cache
-        QNanoDataElement *f = dataCache->object(m_filename);
+        const QNanoDataElement *f = dataCache->value(m_filename);
         m_width = f->width;
         m_height = f->height;
         m_id = f->id;
@@ -80,20 +80,13 @@ int QNanoImage::getID(NVGcontext* nvg)
         } else {
             QByteArray array = file.readAll();
             int length = array.size();
-            f->data = (unsigned char*)&array.constData()[0];
-            m_id = nvgCreateImageMem(nvg, m_flags, f->data, length);
+            unsigned char* data = (unsigned char*)&array.constData()[0];
+            m_id = nvgCreateImageMem(nvg, m_flags, data, length);
             f->id = m_id;
             nvgImageSize(nvg, m_id, &m_width, &m_height);
             f->width = m_width;
             f->height = m_height;
-            int kbsize = length / 1000;
-            dataCache->insert(m_filename, f, kbsize);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
-            qInfo() << "Adding image into cache";
-            qInfo() << "Image filename: " << m_filename;
-            qInfo() << "Image size: (" << m_width << " x "<< m_height << ") " << kbsize << "kb";
-            qInfo() << "Data buffer load: " << 100.0*dataCache->totalCost()/dataCache->maxCost() << "%";
-#endif
+            dataCache->insert(m_filename, f);
         }
     }
     return m_id;

--- a/libqnanopainter/qnanopainter.cpp
+++ b/libqnanopainter/qnanopainter.cpp
@@ -115,13 +115,6 @@
     \sa setPixelAlign(), setPixelAlignText()
 */
 
-#ifndef QNANO_DATA_BUFFER_SIZE
-    // Define buffer size for font and images in kbytes
-    #define QNANO_DATA_BUFFER_SIZE 8000
-    // NOTE: If buffer is too small for handling all fonts, it cause assert like this:
-    // -> Assertion failed: (0), function stbtt_FindGlyphIndex, file ../../../qnanopainter/qnanopainter/nanovg/stb_truetype.h, line 1106.
-    // So you can increase the cache size if using many different font files.
-#endif
 
 /*!
     Constructs a painter.
@@ -136,7 +129,6 @@ QNanoPainter::QNanoPainter()
     , m_pixelAlign(QNanoPainter::PIXEL_ALIGN_NONE)
     , m_pixelAlignText(QNanoPainter::PIXEL_ALIGN_NONE)
 {
-    m_dataCache.setMaxCost(QNANO_DATA_BUFFER_SIZE);
 }
 
 /*!
@@ -145,6 +137,7 @@ QNanoPainter::QNanoPainter()
 
 QNanoPainter::~QNanoPainter()
 {
+    qDeleteAll(m_dataCache);
 }
 
 // *** State Handling ***

--- a/libqnanopainter/qnanopainter.h
+++ b/libqnanopainter/qnanopainter.h
@@ -221,7 +221,7 @@ private:
     void _checkAlignPixelsAdjustOne(float *a);
 
     // TODO: Consider implementing QNanoDataCache class with methods instead of this
-    QCache<QString, QNanoDataElement> m_dataCache;
+    QMap<QString, QNanoDataElement*> m_dataCache;
 
     NVGcontext* m_nvgContext;
     QNanoPainter::TextAlign m_textAlign;


### PR DESCRIPTION
* msvc compiler does not support variable c arrays ( not even 2015) => replace by QVarLengthArray.
* msvc 2012 compiler does not support c99 variable init in code =>  move vars to beginning of scope.
* make exe use glesv2 as nanopainter does not support qt dynamic gl feature.
* this also compiles for wec2013 which only has glesv2 , not tested yet as no device available here.

tested with vs2015 64 bit + qt 5.6 beta, vs2012  32 bit + qt 5.5.1, mac osx 10.11.2 + qt 5.6 beta


