### PR TITLE
cleanup use of painter() vs. paint() parameter, in favour of painter()

### DIFF
--- a/examples/gallery/src/galleryitempainter.cpp
+++ b/examples/gallery/src/galleryitempainter.cpp
@@ -27,10 +27,8 @@ void GalleryItemPainter::synchronize(QNanoQuickItem *item)
     }
 }
 
-void GalleryItemPainter::paint(QNanoPainter *painter)
+void GalleryItemPainter::paint()
 {
-    Q_UNUSED(painter)
-
     // Draw similarly colored rectangles
     switch (m_viewIndex) {
     case 0:

--- a/examples/gallery/src/galleryitempainter.h
+++ b/examples/gallery/src/galleryitempainter.h
@@ -17,7 +17,7 @@ public:
 
     // Reimplement
     void synchronize(QNanoQuickItem *item);
-    void paint(QNanoPainter *painter);
+    void paint();
 
 private:
 

--- a/examples/helloworld/helloitem.h
+++ b/examples/helloworld/helloitem.h
@@ -14,32 +14,32 @@ public:
     {
     }
 
-    void paint(QNanoPainter *p)
+    void paint()
     {
         // Paint the background circle
-        p->beginPath();
-        p->circle(width()*0.5, height()*0.5, width()*0.46);
+        painter()->beginPath();
+        painter()->circle(width()*0.5, height()*0.5, width()*0.46);
         QNanoRadialGradient gradient1(width()*0.5, height()*0.4, width()*0.6, width()*0.2);
         gradient1.setStartColor("#808080");
         gradient1.setEndColor("#404040");
-        p->setFillStyle(gradient1);
-        p->fill();
-        p->setStrokeStyle("#202020");
-        p->setLineWidth(width()*0.02);
-        p->stroke();
+        painter()->setFillStyle(gradient1);
+        painter()->fill();
+        painter()->setStrokeStyle("#202020");
+        painter()->setLineWidth(width()*0.02);
+        painter()->stroke();
         // Hello text
-        p->setTextAlign(QNanoPainter::ALIGN_CENTER);
-        p->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
+        painter()->setTextAlign(QNanoPainter::ALIGN_CENTER);
+        painter()->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
         QNanoFont font1(QNanoFont::DEFAULT_FONT_BOLD_ITALIC);
         font1.setPixelSize(width()*0.08);
-        p->setFont(font1);
-        p->setFillStyle("#B0D040");
-        p->fillText("HELLO", width()*0.5, height()*0.4);
+        painter()->setFont(font1);
+        painter()->setFillStyle("#B0D040");
+        painter()->fillText("HELLO", width()*0.5, height()*0.4);
         // QNanoPainter text
         QNanoFont font2(QNanoFont::DEFAULT_FONT_THIN);
         font2.setPixelSize(width()*0.18);
-        p->setFont(font2);
-        p->fillText("QNanoPainter", width()*0.5, height()*0.5);
+        painter()->setFont(font2);
+        painter()->fillText("QNanoPainter", width()*0.5, height()*0.5);
     }
 };
 

--- a/examples/mouse_events/eventitempainter.cpp
+++ b/examples/mouse_events/eventitempainter.cpp
@@ -27,20 +27,20 @@ void EventItemPainter::synchronize(QNanoQuickItem *item)
     }
 }
 
-void EventItemPainter::paint(QNanoPainter *p)
+void EventItemPainter::paint()
 {
-    p->setGlobalAlpha(m_hoverEnabled && !m_hovered ? 0.5 : 1.0);
+    painter()->setGlobalAlpha(m_hoverEnabled && !m_hovered ? 0.5 : 1.0);
     // Background
-    p->beginPath();
-    p->setFillStyle(0xFF408070);
-    p->setStrokeStyle(0xFFD0D0D0);
-    p->rect(0, 0, width(), height());
-    p->setLineWidth(2);
-    p->fill();
-    p->stroke();
+    painter()->beginPath();
+    painter()->setFillStyle(0xFF408070);
+    painter()->setStrokeStyle(0xFFD0D0D0);
+    painter()->rect(0, 0, width(), height());
+    painter()->setLineWidth(2);
+    painter()->fill();
+    painter()->stroke();
 
     // Draw boxes
-    p->setLineWidth(1);
+    painter()->setLineWidth(1);
     for (int i=0 ; i<m_items.count() ; i++)
     {
         QRectF box = m_items.at(i);
@@ -48,27 +48,27 @@ void EventItemPainter::paint(QNanoPainter *p)
         bool isPressed = (m_pressedItem == i);
         QNanoColor fillColor(isPressed ? 0xFFFF0000 : isActive ? 0xFFFFFFFF : 0xFF000000);
         fillColor.setAlphaF(0.2);
-        p->setFillStyle(fillColor);
-        p->setStrokeStyle(0xFFD0D0D0);
-        p->beginPath();
-        p->rect(box);
-        p->fill();
-        p->stroke();
+        painter()->setFillStyle(fillColor);
+        painter()->setStrokeStyle(0xFFD0D0D0);
+        painter()->beginPath();
+        painter()->rect(box);
+        painter()->fill();
+        painter()->stroke();
         // corner circle
-        p->beginPath();
+        painter()->beginPath();
         bool isResizable = (m_resizableItem == i);
-        p->setFillStyle(isResizable ? 0x80F0F0F0 : 0x00F0F0F0);
-        p->circle(box.x()+box.width(), box.y()+box.height(), m_circleSize);
-        p->stroke();
-        p->fill();
+        painter()->setFillStyle(isResizable ? 0x80F0F0F0 : 0x00F0F0F0);
+        painter()->circle(box.x()+box.width(), box.y()+box.height(), m_circleSize);
+        painter()->stroke();
+        painter()->fill();
         // Item number
-        p->setFillStyle(0xFFE0E0E0);
-        p->setTextAlign(QNanoPainter::ALIGN_CENTER);
-        p->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
+        painter()->setFillStyle(0xFFE0E0E0);
+        painter()->setTextAlign(QNanoPainter::ALIGN_CENTER);
+        painter()->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
         QNanoFont font(QNanoFont::DEFAULT_FONT_BOLD);
         font.setPointSize(12);
-        p->setFont(font);
-        p->fillText(QString::number(i+1), box.center());
+        painter()->setFont(font);
+        painter()->fillText(QString::number(i+1), box.center());
     }
 }
 

--- a/examples/mouse_events/eventitempainter.h
+++ b/examples/mouse_events/eventitempainter.h
@@ -9,7 +9,7 @@ public:
     EventItemPainter();
     // Reimplement
     void synchronize(QNanoQuickItem *item);
-    void paint(QNanoPainter *p);
+    void paint();
 
 private:
     QList<QRectF> m_items;

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.cpp
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.cpp
@@ -34,10 +34,8 @@ void DemoQNanoItemPainter::synchronize(QNanoQuickItem *item)
 }
 
 
-void DemoQNanoItemPainter::paint(QNanoPainter *painter)
+void DemoQNanoItemPainter::paint()
 {
-    m_painter = painter;
-
     qreal w = width();
     qreal h = height();
     qreal t = m_animationTime;
@@ -97,37 +95,37 @@ void DemoQNanoItemPainter::drawGraphLine(float x, float y, float w, float h, int
 
     // Draw graph background area
     QNanoLinearGradient bg(x,y,x,y+h, m_color1, m_color2);
-    m_painter->beginPath();
-    m_painter->moveTo(sx[0], sy[0]);
+    painter()->beginPath();
+    painter()->moveTo(sx[0], sy[0]);
     for (i = 1; i < items; i++)
-        m_painter->bezierTo(sx[i-1]+dx*0.5f,sy[i-1], sx[i]-dx*0.5f,sy[i], sx[i],sy[i]);
-    m_painter->lineTo(x+w, y);
-    m_painter->lineTo(x, y);
-    m_painter->setFillStyle(bg);
-    m_painter->fill();
+        painter()->bezierTo(sx[i-1]+dx*0.5f,sy[i-1], sx[i]-dx*0.5f,sy[i], sx[i],sy[i]);
+    painter()->lineTo(x+w, y);
+    painter()->lineTo(x, y);
+    painter()->setFillStyle(bg);
+    painter()->fill();
 
     // Draw graph line
-    m_painter->beginPath();
-    m_painter->moveTo(sx[0], sy[0]);
+    painter()->beginPath();
+    painter()->moveTo(sx[0], sy[0]);
     for (i = 1; i < items; i++)
-        m_painter->bezierTo(sx[i-1]+dx*0.5f,sy[i-1], sx[i]-dx*0.5f,sy[i], sx[i],sy[i]);
-    m_painter->setStrokeStyle(m_colorGray);
-    m_painter->setLineWidth(dotSize*0.4);
-    m_painter->stroke();
+        painter()->bezierTo(sx[i-1]+dx*0.5f,sy[i-1], sx[i]-dx*0.5f,sy[i], sx[i],sy[i]);
+    painter()->setStrokeStyle(m_colorGray);
+    painter()->setLineWidth(dotSize*0.4);
+    painter()->stroke();
 
     // Draw dot borders
-    m_painter->beginPath();
+    painter()->beginPath();
     for (i = 0; i < items; i++)
-        m_painter->circle(sx[i], sy[i], dotSize);
-    m_painter->setFillStyle(m_colorBlack);
-    m_painter->fill();
+        painter()->circle(sx[i], sy[i], dotSize);
+    painter()->setFillStyle(m_colorBlack);
+    painter()->fill();
 
     // Draw dot content
-    m_painter->beginPath();
+    painter()->beginPath();
     for (i = 0; i < items; i++)
-        m_painter->circle(sx[i], sy[i], dotSize*0.6);
-    m_painter->setFillStyle(m_colorWhite);
-    m_painter->fill();
+        painter()->circle(sx[i], sy[i], dotSize*0.6);
+    painter()->setFillStyle(m_colorWhite);
+    painter()->fill();
 }
 
 void DemoQNanoItemPainter::drawGraphBars(float x, float y, float w, float h, int items, float t) {
@@ -149,17 +147,17 @@ void DemoQNanoItemPainter::drawGraphBars(float x, float y, float w, float h, int
     }
 
     // Draw graph bars
-    m_painter->beginPath();
+    painter()->beginPath();
     for (i = 0; i < items; i++) {
-        m_painter->rect((int)sx[i]+0.5, (int)y+1.5, (int)barWidth, (int)sy[i]);
+        painter()->rect((int)sx[i]+0.5, (int)y+1.5, (int)barWidth, (int)sy[i]);
     }
     qreal lineWidth = 0.5 + w * 0.002;
-    m_painter->setLineWidth(lineWidth);
-    m_painter->setLineJoin(QNanoPainter::JOIN_MITER);
-    m_painter->setFillStyle(m_color3);
-    m_painter->setStrokeStyle(m_colorBlack);
-    m_painter->fill();
-    m_painter->stroke();
+    painter()->setLineWidth(lineWidth);
+    painter()->setLineJoin(QNanoPainter::JOIN_MITER);
+    painter()->setFillStyle(m_color3);
+    painter()->setStrokeStyle(m_colorBlack);
+    painter()->fill();
+    painter()->stroke();
 }
 
 void DemoQNanoItemPainter::drawGraphCircles(float x, float y, float w, float h, int items, float t)
@@ -183,30 +181,30 @@ void DemoQNanoItemPainter::drawGraphCircles(float x, float y, float w, float h, 
         a0[i] = -pi/2 + pi2*(((float)items-i)/items)*showAnimationProgress;
     }
 
-    m_painter->setLineWidth(lineWidth);
-    m_painter->setLineJoin(QNanoPainter::JOIN_ROUND);
-    m_painter->setLineCap(QNanoPainter::CAP_ROUND);
+    painter()->setLineWidth(lineWidth);
+    painter()->setLineJoin(QNanoPainter::JOIN_ROUND);
+    painter()->setLineCap(QNanoPainter::CAP_ROUND);
 
     // Draw cicle backgrounds
     qreal r = radius1;
     QNanoColor c_background(215,215,215,50);
-    m_painter->setStrokeStyle(c_background);
+    painter()->setStrokeStyle(c_background);
     for (int i=0 ; i<items ; i++) {
-        m_painter->beginPath();
-        m_painter->circle(cx, cy, r);
-        m_painter->stroke();
+        painter()->beginPath();
+        painter()->circle(cx, cy, r);
+        painter()->stroke();
         r -= (lineWidth + lineMargin);
     }
 
     // Draw circle bars
     r = radius1;
     for (int i=0 ; i<items ; i++) {
-        m_painter->beginPath();
-        m_painter->arc(cx, cy, r, a0[i], a1, QNanoPainter::WINDING_CCW);
+        painter()->beginPath();
+        painter()->arc(cx, cy, r, a0[i], a1, QNanoPainter::WINDING_CCW);
         float s = (float)i/items;
         QNanoColor c(200-150*s, 200-50*s, 100+50*s, 255*showAnimationProgress);
-        m_painter->setStrokeStyle(c);
-        m_painter->stroke();
+        painter()->setStrokeStyle(c);
+        painter()->stroke();
         r -= (lineWidth + lineMargin);
     }
 }
@@ -216,16 +214,16 @@ void DemoQNanoItemPainter::drawIcons(float x, float y, float w, float h, int ite
     // Note: Adjust font size to match QPainter sizing
     qreal fontSize = w/22.0 * 1.32 - 1;
     m_testFont.setPixelSize(fontSize);
-    m_painter->setFont(m_testFont);
-    m_painter->setFillStyle("#FFFFFF");
-    m_painter->setTextAlign(QNanoPainter::ALIGN_CENTER);
-    m_painter->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
+    painter()->setFont(m_testFont);
+    painter()->setFillStyle("#FFFFFF");
+    painter()->setTextAlign(QNanoPainter::ALIGN_CENTER);
+    painter()->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
     qreal size = w/12;
     for (int i=0 ; i<items ; i++) {
         qreal xp = x + (w-size)/items*i;
         qreal yp = y + h*0.5 + h * sinf((i+1) * t * 0.1) * 0.5;
-        m_painter->drawImage(m_circleImage, QRectF(xp, yp, size, size));
-        m_painter->fillText(QString::number(i+1), QRectF(xp, yp+size/2, size, size));
+        painter()->drawImage(m_circleImage, QRectF(xp, yp, size, size));
+        painter()->fillText(QString::number(i+1), QRectF(xp, yp+size/2, size, size));
     }
 }
 
@@ -233,31 +231,31 @@ void DemoQNanoItemPainter::drawRuler(float x, float y, float w, float h, float t
 {
     float posX = x + w*0.05;
     double space = w*0.03 + sinf(t)*w*0.02;
-    m_painter->setTextAlign(QNanoPainter::ALIGN_CENTER);
-    m_painter->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
+    painter()->setTextAlign(QNanoPainter::ALIGN_CENTER);
+    painter()->setTextBaseline(QNanoPainter::BASELINE_MIDDLE);
     // Note: Adjust font size to match QPainter sizing
     qreal fontSize = w/35.0 * 1.32 - 1;
     m_testFont.setPixelSize(fontSize);
-    m_painter->setFont(m_testFont);
-    m_painter->setStrokeStyle("#E0E0E0");
-    m_painter->setFillStyle("#E0E0B0");
-    m_painter->beginPath();
+    painter()->setFont(m_testFont);
+    painter()->setStrokeStyle("#E0E0E0");
+    painter()->setFillStyle("#E0E0B0");
+    painter()->beginPath();
     int i = 0;
     while (posX < w) {
-        m_painter->moveTo(posX, y);
+        painter()->moveTo(posX, y);
         float height = h*0.2;
         QPointF textPoint(posX, y+h);
         if (i%10==0) {
             height = h*0.5;
-            m_painter->fillText(QString::number(i), textPoint);
+            painter()->fillText(QString::number(i), textPoint);
         } else if (i%5==0) {
             height = h*0.3;
-            if (space > w*0.02) m_painter->fillText(QString::number(i), textPoint);
+            if (space > w*0.02) painter()->fillText(QString::number(i), textPoint);
         }
-        m_painter->lineTo(posX, y+height);
+        painter()->lineTo(posX, y+height);
         posX += space;
         i++;
     }
-    m_painter->setLineWidth(1.0f);
-    m_painter->stroke();
+    painter()->setLineWidth(1.0f);
+    painter()->stroke();
 }

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.h
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.h
@@ -13,7 +13,7 @@ public:
 
     // Reimplement
     void synchronize(QNanoQuickItem *item);
-    void paint(QNanoPainter *painter);
+    void paint();
 
 private:
     void drawGraphLine(float x, float y, float w, float h, int items, float t);

--- a/libqnanopainter/qnanoquickitempainter.cpp
+++ b/libqnanopainter/qnanoquickitempainter.cpp
@@ -273,7 +273,7 @@ void QNanoQuickItemPainter::render()
         if ((m_itemWidth > 0 && m_itemHeight > 0) || m_setupDone) {
             m_setupDone = true;
             prepaint();
-            paint(m_painter);
+            paint();
             postpaint();
         }
     }

--- a/libqnanopainter/qnanoquickitempainter.h
+++ b/libqnanopainter/qnanoquickitempainter.h
@@ -39,7 +39,7 @@ public:
     explicit QNanoQuickItemPainter();
     ~QNanoQuickItemPainter();
 
-    virtual void paint(QNanoPainter *painter) = 0;
+    virtual void paint() = 0;
     virtual void synchronize(QNanoQuickItem *item);
     virtual void sizeChanged(float width, float height);
 


### PR DESCRIPTION
gallery example ignores paint() pianter parameter and use base class pianter function.
other samples use painter parameter. demoqnanpoitempainter  even adds a m_painter member
overlaying the m_painter base member. this is cleaned up to paimt() having no parameter
and painter() is used everywhere. no m_painter member in derived classes
