### PR TITLE
share QNanoPainter, owning NVG Context, between QNanoPainter instances.

### DIFF
--- a/libqnanopainter/qnanopainter.cpp
+++ b/libqnanopainter/qnanopainter.cpp
@@ -219,6 +219,11 @@ void QNanoPainter::restore()
 
 void QNanoPainter::reset()
 {
+    m_textAlign = QNanoPainter::ALIGN_LEFT;
+    m_textBaseline = QNanoPainter::BASELINE_ALPHABETIC;
+    m_fontSet = false;
+    m_pixelAlign = QNanoPainter::PIXEL_ALIGN_NONE;
+    m_pixelAlignText = QNanoPainter::PIXEL_ALIGN_NONE;
     nvgReset(nvgCtx());
 }
 

--- a/libqnanopainter/qnanopainter.cpp
+++ b/libqnanopainter/qnanopainter.cpp
@@ -20,7 +20,22 @@
 **********************************************************/
 
 #include "qnanopainter.h"
+#if defined(Q_OS_IOS)
+#include <OpenGLES/ES2/gl.h>
+#elif defined(Q_OS_MAC)
+#include <OpenGL/gl.h>
+#else
+#include <GLES2/gl2.h>
+#endif
+
+#ifdef QT_OPENGL_ES_2
+#define NANOVG_GLES2_IMPLEMENTATION
+#else
+#define NANOVG_GL2_IMPLEMENTATION
+#endif
+
 #include "nanovg/nanovg.h"
+#include "nanovg/nanovg_gl.h"
 
 /*!
     \class QNanoPainter
@@ -129,6 +144,17 @@ QNanoPainter::QNanoPainter()
     , m_pixelAlign(QNanoPainter::PIXEL_ALIGN_NONE)
     , m_pixelAlignText(QNanoPainter::PIXEL_ALIGN_NONE)
 {
+    // Initialize NanoVG for correct GL version
+    // TODO: Allow to enable/disable NVG_DEBUG, possibly some own general debug define
+#ifdef QT_OPENGL_ES_2
+    m_nvgContext = nvgCreateGLES2(NVG_ANTIALIAS | NVG_DEBUG);
+#else
+    m_nvgContext = nvgCreateGL2(NVG_ANTIALIAS | NVG_DEBUG);
+#endif
+
+    Q_ASSERT_X(m_nvgContext, "QNanoPainter::QNanoPainter", "Could not init nanovg!");
+
+
 }
 
 /*!
@@ -137,6 +163,14 @@ QNanoPainter::QNanoPainter()
 
 QNanoPainter::~QNanoPainter()
 {
+    if (m_nvgContext) {
+#ifdef QT_OPENGL_ES_2
+    nvgDeleteGLES2(m_nvgContext);
+#else
+    nvgDeleteGL2(m_nvgContext);
+#endif
+    }
+
     qDeleteAll(m_dataCache);
 }
 
@@ -1200,6 +1234,18 @@ void QNanoPainter::setPixelAlignText(PixelAlign align)
 double QNanoPainter::devicePixelRatio() const
 {
     return m_devicePixelRatio;
+}
+
+void QNanoPainter::enableHighQualityRendering(bool enable)
+{
+    GLNVGcontext *gl = static_cast<GLNVGcontext*>(nvgInternalParams(nvgCtx())->userPtr);
+    if (gl) {
+        if (enable) {
+            gl->flags |= NVG_STENCIL_STROKES;
+        } else {
+            gl->flags &= ~NVG_STENCIL_STROKES;
+        }
+    }
 }
 
 /*

--- a/libqnanopainter/qnanopainter.h
+++ b/libqnanopainter/qnanopainter.h
@@ -180,7 +180,7 @@ public:
     void setPixelAlign(PixelAlign align);
     void setPixelAlignText(PixelAlign align);
     double devicePixelRatio() const;
-
+    void enableHighQualityRendering(bool enable);
 /* TODO: Update these for better API
 
     // Calculates the glyph x positions of the specified text. If end is specified only the sub-string will be used.
@@ -207,9 +207,6 @@ private:
     friend class QNanoLinearGradient;
     friend class QNanoRadialGradient;
 
-    inline void setNvgCtx(NVGcontext* nvg) {
-        this->m_nvgContext = nvg;
-    }
     inline NVGcontext* nvgCtx() const {
         return m_nvgContext;
     }

--- a/libqnanopainter/qnanoquickitempainter.cpp
+++ b/libqnanopainter/qnanoquickitempainter.cpp
@@ -25,23 +25,6 @@
 #include <QDebug>
 #include <QQuickWindow>
 
-#if defined(Q_OS_IOS)
-#include <OpenGLES/ES2/gl.h>
-#elif defined(Q_OS_MAC)
-#include <OpenGL/gl.h>
-#else
-#include <GLES2/gl2.h>
-#endif
-
-#ifdef QT_OPENGL_ES_2
-#define NANOVG_GLES2_IMPLEMENTATION
-#else
-#define NANOVG_GL2_IMPLEMENTATION
-#endif
-
-#include "nanovg/nanovg.h"
-#include "nanovg/nanovg_gl.h"
-
 /*!
     \class QNanoQuickItemPainter
     \brief The QNanoQuickItemPainter handles all painting of a QNanoQuickItem.
@@ -55,8 +38,7 @@
 */
 
 QNanoQuickItemPainter::QNanoQuickItemPainter()
-    : m_vg(nullptr)
-    , m_painter(nullptr)
+    : m_painter(nullptr)
     , m_fillColor(0.0, 0.0, 0.0, 0.0)
     , m_itemWidth(0.0f)
     , m_itemHeight(0.0f)
@@ -84,13 +66,6 @@ QNanoQuickItemPainter::~QNanoQuickItemPainter()
         m_painter = nullptr;
     }
 
-    if (m_vg) {
-#ifdef QT_OPENGL_ES_2
-    nvgDeleteGLES2(m_vg);
-#else
-    nvgDeleteGL2(m_vg);
-#endif
-    }
 }
 
 /*!
@@ -190,15 +165,9 @@ QColor QNanoQuickItemPainter::fillColor() const
 // Called by QNanoFBORenderer::setItemPainter, initializes NanoVG & OpenGL
 void QNanoQuickItemPainter::initialize()
 {
-    // Initialize NanoVG for correct GL version
-    // TODO: Allow to enable/disable NVG_DEBUG, possibly some own general debug define
-#ifdef QT_OPENGL_ES_2
-    m_vg = nvgCreateGLES2(NVG_ANTIALIAS | NVG_DEBUG);
-#else
-    m_vg = nvgCreateGL2(NVG_ANTIALIAS | NVG_DEBUG);
-#endif
-
-    Q_ASSERT_X(m_vg, "initialize", "Could not init nanovg!");
+    if (!m_painter) {
+        m_painter = new QNanoPainter();
+    }
 
     // Initialize QOpenGLFunctions for the context
     initializeOpenGLFunctions();
@@ -211,17 +180,17 @@ void QNanoQuickItemPainter::prepaint()
     glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
 
     // Note: Last parameter can be used to render in lower resolution
-    nvgBeginFrame(m_vg, m_itemWidth, m_itemHeight, m_devicePixelRatio);
+    nvgBeginFrame(m_painter->nvgCtx(), m_itemWidth, m_itemHeight, m_devicePixelRatio);
 }
 
 void QNanoQuickItemPainter::postpaint()
 {
 #ifdef QNANO_DEBUG
-    m_drawDebug = nvgDrawDebug(m_vg);
+    m_drawDebug = nvgDrawDebug(m_painter->nvgCtx());
     paintDrawDebug();
 #endif
 
-    nvgEndFrame(m_vg);
+    nvgEndFrame(m_painter->nvgCtx());
 }
 
 void QNanoQuickItemPainter::presynchronize(QQuickFramebufferObject *item)
@@ -234,15 +203,7 @@ void QNanoQuickItemPainter::presynchronize(QQuickFramebufferObject *item)
         m_pixelAlignText = realItem->pixelAlignText();
         m_fillColor = realItem->fillColor();
         m_devicePixelRatio = realItem->window()->devicePixelRatio();
-
-        GLNVGcontext *gl = static_cast<GLNVGcontext*>(nvgInternalParams(m_vg)->userPtr);
-        if (gl) {
-            if (realItem->highQualityRendering()) {
-                gl->flags |= NVG_STENCIL_STROKES;
-            } else {
-                gl->flags &= ~NVG_STENCIL_STROKES;
-            }
-        }
+        m_painter->enableHighQualityRendering(realItem->highQualityRendering());
     }
 
 #ifdef QNANO_DEBUG
@@ -254,28 +215,21 @@ void QNanoQuickItemPainter::presynchronize(QQuickFramebufferObject *item)
 
 void QNanoQuickItemPainter::render()
 {
-    if (m_vg) {
 
-        if (!m_painter) {
-            m_painter = new QNanoPainter();
-            m_painter->setNvgCtx(m_vg);
-        }
+    // Update antialiasing if needed
+    nvgInternalParams(m_painter->nvgCtx())->edgeAntiAlias = m_antialiasing;
 
-        // Update antialiasing if needed
-        nvgInternalParams(m_vg)->edgeAntiAlias = m_antialiasing;
+    m_painter->setPixelAlign(static_cast<QNanoPainter::PixelAlign>(m_pixelAlign));
+    m_painter->setPixelAlignText(static_cast<QNanoPainter::PixelAlign>(m_pixelAlignText));
+    m_painter->m_devicePixelRatio = m_devicePixelRatio;
 
-        m_painter->setPixelAlign(static_cast<QNanoPainter::PixelAlign>(m_pixelAlign));
-        m_painter->setPixelAlignText(static_cast<QNanoPainter::PixelAlign>(m_pixelAlignText));
-        m_painter->m_devicePixelRatio = m_devicePixelRatio;
-
-        // Draw only when item has visible size. This way setup and painting is
-        // not called until size has been properly set.
-        if ((m_itemWidth > 0 && m_itemHeight > 0) || m_setupDone) {
-            m_setupDone = true;
-            prepaint();
-            paint(m_painter);
-            postpaint();
-        }
+    // Draw only when item has visible size. This way setup and painting is
+    // not called until size has been properly set.
+    if ((m_itemWidth > 0 && m_itemHeight > 0) || m_setupDone) {
+        m_setupDone = true;
+        prepaint();
+        paint(m_painter);
+        postpaint();
     }
 }
 

--- a/libqnanopainter/qnanoquickitempainter.h
+++ b/libqnanopainter/qnanoquickitempainter.h
@@ -26,6 +26,7 @@
 #include <QtQuick/QQuickFramebufferObject>
 #include <QColor>
 #include <QElapsedTimer>
+#include <QSharedPointer>
 #include "qnanopainter.h"
 #include "qnanoquickitem.h"
 
@@ -43,7 +44,7 @@ public:
     virtual void sizeChanged(float width, float height);
 
     QColor fillColor() const;
-    inline QNanoPainter *painter() const
+    inline QSharedPointer<QNanoPainter> painter() const
     {
         return m_painter;
     }
@@ -73,7 +74,7 @@ private:
 
     QNanoQuickItem *m_parentItem;
 
-    QNanoPainter *m_painter;
+    QSharedPointer<QNanoPainter> m_painter;
     QColor m_fillColor;
     float m_itemWidth, m_itemHeight;
     double m_devicePixelRatio;

--- a/libqnanopainter/qnanoquickitempainter.h
+++ b/libqnanopainter/qnanoquickitempainter.h
@@ -29,7 +29,6 @@
 #include "qnanopainter.h"
 #include "qnanoquickitem.h"
 
-struct NVGcontext;
 
 class QNanoQuickItemPainter : public QObject, protected QOpenGLFunctions
 {
@@ -73,7 +72,7 @@ private:
     void setSize(float width, float height);
 
     QNanoQuickItem *m_parentItem;
-    NVGcontext* m_vg;
+
     QNanoPainter *m_painter;
     QColor m_fillColor;
     float m_itemWidth, m_itemHeight;


### PR DESCRIPTION
This is a proposal, how QNanoPainter can be shared between instances of ItemPainter. NVG context was moved into QNanoPainter for this. The fonts and images stored in the context, can now also be shared between instances of ItemPainter, so also are shared between QNanoQuickItems. This should save a lot of memory and creation time.