### PR TITLE
Fix build failures on Raspberry Pi when using latest Raspbian Stretch distro and Qt5.12.3

### DIFF
--- a/libqnanopainter/private/qnanobackend.h
+++ b/libqnanopainter/private/qnanobackend.h
@@ -2,10 +2,14 @@
 #define QNANOBACKEND_H
 
 #if defined(QNANO_QT_GL_INCLUDE)
-// Let the Qt include OpenGL headers
+// Let Qt include OpenGL headers
 
 #define GL_GLEXT_PROTOTYPES
 #include <QtGui/qopengl.h>
+
+#if defined(QNANO_RASPBIAN_QUIRKS)
+#include <QtGui/qopengles2ext.h>
+#endif //QNANO_RASPBIAN_QUIRKS
 
 #else
 // Manually include OpenGL headers


### PR DESCRIPTION
Fix compilation errors by including missing GLES2 header needed to compile for Raspberry Pi using Raspbian Stretch proprietary Broadcom OpenGL under /opt/vc/include. This change enables only the EGLFS backend to allow QNanoPainter to build and run on Raspberry Pi .

See https://github.com/QUItCoding/qnanopainter/issues/45 for details.