### PR TITLE
Compile and run QNanoPainter using Qt6.0.0-alpha

### DIFF
--- a/examples/gallery/mouse_events/src/eventitem.cpp
+++ b/examples/gallery/mouse_events/src/eventitem.cpp
@@ -3,6 +3,10 @@
 #include <QtMath>
 #include <QCursor>
 
+#if (QT_VERSION >= 0x060000)         // Qt6 -- qrand() is gone.
+#include <QRandomGenerator>
+#endif /* (QT_VERSION >= 0x060000) */
+
 EventItem::EventItem(QQuickItem *parent)
     :  QNanoQuickItem(parent)
 {
@@ -21,7 +25,11 @@ QNanoQuickItemPainter* EventItem::createItemPainter() const
 
 void EventItem::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
+#if (QT_VERSION >= 0x060000) //Qt6 -- renamed to geometryChange()
+    QQuickItem::geometryChange(newGeometry, oldGeometry);
+#else                        //Qt5 -- had geometryChanged()
     QQuickItem::geometryChanged(newGeometry, oldGeometry);
+#endif
     if (widthValid() && heightValid()) {
         m_circleSize = 2 + int(qMin(width(), height())*0.01);
         generateRandomItems();
@@ -171,16 +179,22 @@ int EventItem::resizeItemAt(QPointF pos)
     return -1;
 }
 
+#if (QT_VERSION >= 0x060000)         // qrand() gone in Qt6
+#define QRAND() QRandomGenerator::global()->generate()
+#else
+#define QRAND() qrand()
+#endif /* (QT_VERSION >= 0x060000) */
+
 void EventItem::generateRandomItems()
 {
     m_items.clear();
     int margin = int(width()*0.05);
-    int items = 2 + qrand()%150;
+    int items = 2 + QRAND()%150;
     for (int i=0; i<items ; i++) {
-        double w = qrand() % int(width()*0.2) + margin;
-        double h = qrand() % int(height()*0.2) + margin;
-        double x = qrand() % int(width()-w-margin*2) + margin;
-        double y = qrand() % int(height()-h-margin*2) + margin;
+        double w = QRAND() % int(width()*0.2) + margin;
+        double h = QRAND() % int(height()*0.2) + margin;
+        double x = QRAND() % int(width()-w-margin*2) + margin;
+        double y = QRAND() % int(height()-h-margin*2) + margin;
         m_items << QRectF(x, y, w, h);
     }
     update();

--- a/examples/hellowidget/hellowidget.pro
+++ b/examples/hellowidget/hellowidget.pro
@@ -2,6 +2,10 @@ TEMPLATE = app
 
 QT += widgets
 
+equals(QT_MAJOR_VERSION, 6) { ## for Qt6 need openglwidgets module to define QOpenGLWidget
+    QT += openglwidgets       ## see https://doc-snapshots.qt.io/qt6-dev/sourcebreaks.html#changes-to-qt-ope
+}                             ## NB: "QOpenGLWidget has been moved to its own openglwidgets module. Applications relying on QOpenGLWidget should add QT += openglwidgets to their project file."
+
 SOURCES += main.cpp
 
 HEADERS += \

--- a/libqnanopainter/include.pri
+++ b/libqnanopainter/include.pri
@@ -104,6 +104,10 @@ win32 {
     }
 }
 
+equals(QT_MAJOR_VERSION, 6) { ## for Qt6 need opengl module
+    QT += opengl              ## see https://doc-snapshots.qt.io/qt6-dev/qtopengl-index.html
+}                             ## NB: "Warning: This module should not be used anymore for new code. Please use the corresponding OpenGL classes in Qt GUI." ( https://doc-snapshots.qt.io/qt6-dev/qtgui-index.html#opengl-and-opengl-es-integration )
+
 # When building for embedded devices you can define manually which
 # backends are supported
 #DEFINES += QNANO_BUILD_GLES_BACKENDS

--- a/libqnanopainter/qnanoquickitempainter.cpp
+++ b/libqnanopainter/qnanoquickitempainter.cpp
@@ -28,6 +28,10 @@
 #include <QOpenGLFunctions>
 #include <QtMath>
 
+#if (QT_VERSION >= 0x060000)         // changes for Qt6
+#include <QQuickOpenGLUtils>         // for QQuickOpenGLUtils::resetOpenGLState()
+#endif /* (QT_VERSION >= 0x060000) */
+
 /*!
     \class QNanoQuickItemPainter
     \brief The QNanoQuickItemPainter handles all painting of a QNanoQuickItem.
@@ -335,7 +339,11 @@ void QNanoQuickItemPainter::render()
     }
     // Reset the GL state for Qt side
     if (m_window) {
+#if (QT_VERSION >= 0x060000)         //API changed for Qt6
+        QQuickOpenGLUtils::resetOpenGLState();
+#else
         m_window->resetOpenGLState();
+#endif /* (QT_VERSION >= 0x060000) */
     }
 
 }

--- a/libqnanopainter/qnanoquickitempainter.h
+++ b/libqnanopainter/qnanoquickitempainter.h
@@ -22,7 +22,11 @@
 #ifndef QNANOQUICKITEMPAINTER_H
 #define QNANOQUICKITEMPAINTER_H
 
+#if (QT_VERSION >= 0x060000)
+#include <QtOpenGL>          //for Qt>=6.0.0 opengl compatibility module needed (QT += opengl)
+#else                        //for Qt5 -- original code.
 #include <QtGui/QOpenGLFunctions>
+#endif /* (QT_VERSION >= 0x060000) */
 #include <QtQuick/QQuickFramebufferObject>
 #include <QColor>
 #include <QElapsedTimer>


### PR DESCRIPTION
This PR resolves  issue: " Compilation errors with Qt6.0.0 #56 "
allowing qnanopainter to compile and run on Qt6.0.0-alpha release ( https://www.qt.io/blog/qt-6.0-alpha-released ).