### PR TITLE
Compile and run with Qt6.0.0-beta & eliminate associated Qt5.15 deprecation

### DIFF
--- a/examples/gallery/mouse_events/src/eventitem.cpp
+++ b/examples/gallery/mouse_events/src/eventitem.cpp
@@ -3,9 +3,9 @@
 #include <QtMath>
 #include <QCursor>
 
-#if (QT_VERSION >= 0x060000)         // Qt6 -- qrand() is gone.
+#if (QT_VERSION >= 0x050150)         // Qt5.15 -- qrand() deprecated ; Qt6 -- qrand() is gone.
 #include <QRandomGenerator>
-#endif /* (QT_VERSION >= 0x060000) */
+#endif /* (QT_VERSION >= 0x050150) */
 
 EventItem::EventItem(QQuickItem *parent)
     :  QNanoQuickItem(parent)
@@ -29,7 +29,7 @@ void EventItem::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeom
     QQuickItem::geometryChange(newGeometry, oldGeometry);
 #else                        //Qt5 -- had geometryChanged()
     QQuickItem::geometryChanged(newGeometry, oldGeometry);
-#endif
+#endif /* (QT_VERSION >= 0x060000) */
     if (widthValid() && heightValid()) {
         m_circleSize = 2 + int(qMin(width(), height())*0.01);
         generateRandomItems();
@@ -179,11 +179,11 @@ int EventItem::resizeItemAt(QPointF pos)
     return -1;
 }
 
-#if (QT_VERSION >= 0x060000)         // qrand() gone in Qt6
+#if (QT_VERSION >= 0x050150)         // Qt5.15 -- qrand() deprecated ; Qt6 -- qrand() is gone.
 #define QRAND() QRandomGenerator::global()->generate()
 #else
 #define QRAND() qrand()
-#endif /* (QT_VERSION >= 0x060000) */
+#endif /* (QT_VERSION >= 0x050150) */
 
 void EventItem::generateRandomItems()
 {

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.cpp
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.cpp
@@ -18,7 +18,7 @@ DemoQNanoItemPainter::DemoQNanoItemPainter()
     m_color2 = QNanoColor(255,255,255,150);
     m_color3 = QNanoColor(255,255,255,80);
 
-    QNanoImage::ImageFlags imageFlags = nullptr;
+    QNanoImage::ImageFlags imageFlags = {};
 #ifndef Q_OS_WIN
     // Windows ANGLE seems to have issues with mipmaps, use those in all other platforms.
     // See: https://github.com/QUItCoding/qnanopainter/issues/19

--- a/libqnanopainter/qnanoimage.cpp
+++ b/libqnanopainter/qnanoimage.cpp
@@ -75,7 +75,7 @@
 QNanoImage::QNanoImage()
     : m_parentPainter(nullptr)
     , m_imageData(nullptr)
-    , m_flags(nullptr)
+    , m_flags({})
 {
 }
 

--- a/libqnanopainter/qnanoimage.h
+++ b/libqnanopainter/qnanoimage.h
@@ -49,7 +49,7 @@ public:
     QNanoImage();
 
     // Constructs an image with the filename and flags
-    QNanoImage(const QString &filename, ImageFlags flags = nullptr);
+    QNanoImage(const QString &filename, ImageFlags flags = {});
 
     // Set the filename of the image
     void setFilename(const QString &filename);


### PR DESCRIPTION
After updating to Qt6.0.0 beta ( https://www.qt.io/blog/qt-6.0-beta-released ), additional compilation errors were present. This pull request fixes those errors.

Additionally, a small change in applying my qrand() fix from my previously applied Qt6.0.0-alpha pull request eliminates an associated deprecation warning seen when compiling with Qt5.15, by applying the change beginning 5.15, instead of 6.0.