### PR TITLE
QImage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,39 @@ public:
 };
 ```
 
+### Example how to render QImage
+
+QNanoPainter can render QImage. The principle is that on the first render pass the QImage is loaded and put into cache and on the second pass it will be used from the cache.
+
+QImage is automatically converted to the correct pixel format (Format_RGBA8888_Premultiplied).
+
+Here's how to do it in paint function:
+
+```C++:
+    QImage loadImage(const QString &fileName)
+    {
+        // Load and return QImage
+        return QImage();
+    }
+
+    void paint(QNanoPainter *painter)
+    {
+        QString imageFileName; // Path to your image file
+
+        QNanoImage nanoImage = QNanoImage::fromCache(painter, imageFileName);
+        QSize imageSize(nanoImage.width(), nanoImage.height());
+        if (imageSize.isEmpty()) {
+            QImage image(loadImage(imageFileName));
+            if (image.isNull())
+                return;
+
+            nanoImage = QNanoImage(image, imageFileName);
+            imageSize = image.size();
+        }
+
+        // Render QNanoImage using painter
+    }
+```
 
 ## API Reference
 

--- a/libqnanopainter/qnanoimage.cpp
+++ b/libqnanopainter/qnanoimage.cpp
@@ -73,8 +73,6 @@
 */
 
 QNanoImage::QNanoImage()
-    : m_parentPainter(nullptr)
-    , m_flags({})
 {
 }
 
@@ -87,7 +85,14 @@ QNanoImage::QNanoImage()
 */
 
 QNanoImage::QNanoImage(const QString &filename, ImageFlags flags)
-    : m_parentPainter(nullptr)
+    : m_filename(filename)
+    , m_flags(flags)
+{
+    updateUniqueKey();
+}
+
+QNanoImage::QNanoImage(QImage image, const QString &filename, ImageFlags flags)
+    : m_image(new QImage(image))
     , m_filename(filename)
     , m_flags(flags)
 {
@@ -191,6 +196,19 @@ QNanoImage QNanoImage::fromFrameBuffer(const QOpenGLFramebufferObject *fbo, Imag
     return image;
 }
 
+QNanoImage QNanoImage::fromCache(QNanoPainter *painter, const QString &filename, ImageFlags flags)
+{
+    Q_ASSERT(painter);
+    QNanoImage image;
+    image.m_imageData.reset(new QNanoDataElement());
+    image.m_filename = filename;
+    image.m_flags = flags;
+    image.updateUniqueKey();
+    image.m_parentPainter = painter;
+    image.getID(painter->nvgCtx());
+    return image;
+}
+
 // ***** Private *****
 
 /*!
@@ -200,23 +218,40 @@ QNanoImage QNanoImage::fromFrameBuffer(const QOpenGLFramebufferObject *fbo, Imag
 int QNanoImage::getID(NVGcontext* nvg)
 {
     // Image cache should always exist at this point
+    Q_ASSERT(m_parentPainter);
+    if (!m_parentPainter)
+        return -1;
     auto *dataCache = &m_parentPainter->m_dataCache;
-    Q_ASSERT(dataCache);
     if (dataCache->contains(m_uniqueKey)) {
         // Image is in cache
         m_imageData = dataCache->value(m_uniqueKey);
     } else if (m_imageData && m_textureId > 0) {
-        m_imageData->id = m_parentPainter->m_backend->nvglCreateImageFromHandle(m_parentPainter->nvgCtx(), m_textureId,
+        m_imageData->id = m_parentPainter->m_backend->nvglCreateImageFromHandle(nvg, m_textureId,
                                                                                 m_imageData->width, m_imageData->height,
                                                                                 m_flags);
         dataCache->insert(m_uniqueKey, m_imageData);
+    } else if (m_image) {
+        if (m_image->size().isEmpty()) {
+            qWarning() << "Empty image: " << m_filename;
+        } else {
+            if (m_image->format() != QImage::Format_RGBA8888 && m_image->format() != QImage::Format_RGBA8888_Premultiplied) {
+                qWarning() << "Converting image" << m_filename << "from" << m_image->format() << "to" << QImage::Format_RGBA8888_Premultiplied;
+                m_image->convertTo(QImage::Format_RGBA8888_Premultiplied);
+            }
+            m_imageData.reset(new QNanoDataElement());
+            QNanoImage::ImageFlags flags = m_flags;
+            if (m_image->format() == QImage::Format_RGBA8888_Premultiplied)
+                flags |= QNanoImage::PREMULTIPLIED;
+            else
+                flags &= ~QNanoImage::PREMULTIPLIED;
+            m_imageData->id = nvgCreateImageRGBA(nvg, m_image->width(), m_image->height(), flags, m_image->bits());
+            nvgImageSize(nvg, m_imageData->id, &m_imageData->width, &m_imageData->height);
+            dataCache->insert(m_uniqueKey, m_imageData);
+        }
     } else {
         // Image is not yet in cache, so load and add it
         QFile file(m_filename);
-        if (!file.open(QFile::ReadOnly))
-        {
-            qWarning() << "Could not open image file: " << m_filename;
-        } else {
+        if (file.open(QFile::ReadOnly)) {
             m_imageData.reset(new QNanoDataElement());
             QByteArray array = file.readAll();
             int length = array.size();
@@ -226,7 +261,7 @@ int QNanoImage::getID(NVGcontext* nvg)
             dataCache->insert(m_uniqueKey, m_imageData);
         }
     }
-    return m_imageData->id;
+    return m_imageData ? m_imageData->id : -1;
 }
 
 void QNanoImage::setParentPainter(QNanoPainter *parentPainter)

--- a/libqnanopainter/qnanoimage.cpp
+++ b/libqnanopainter/qnanoimage.cpp
@@ -74,7 +74,6 @@
 
 QNanoImage::QNanoImage()
     : m_parentPainter(nullptr)
-    , m_imageData(nullptr)
     , m_flags({})
 {
 }
@@ -89,7 +88,6 @@ QNanoImage::QNanoImage()
 
 QNanoImage::QNanoImage(const QString &filename, ImageFlags flags)
     : m_parentPainter(nullptr)
-    , m_imageData(nullptr)
     , m_filename(filename)
     , m_flags(flags)
 {
@@ -121,8 +119,7 @@ void QNanoImage::setFilename(const QString &filename)
 void QNanoImage::setFrameBuffer(const QOpenGLFramebufferObject *fbo)
 {
     Q_ASSERT(fbo);
-    delete m_imageData;
-    m_imageData = new QNanoDataElement();
+    m_imageData.reset(new QNanoDataElement());
     m_imageData->width = fbo->width();
     m_imageData->height = fbo->height();
     m_textureId = fbo->texture();
@@ -185,7 +182,7 @@ QNanoImage QNanoImage::fromFrameBuffer(const QOpenGLFramebufferObject *fbo, Imag
 {
     Q_ASSERT(fbo);
     QNanoImage image;
-    image.m_imageData = new QNanoDataElement();
+    image.m_imageData.reset(new QNanoDataElement());
     image.m_imageData->width = fbo->width();
     image.m_imageData->height = fbo->height();
     image.m_textureId = fbo->texture();
@@ -220,7 +217,7 @@ int QNanoImage::getID(NVGcontext* nvg)
         {
             qWarning() << "Could not open image file: " << m_filename;
         } else {
-            m_imageData = new QNanoDataElement();
+            m_imageData.reset(new QNanoDataElement());
             QByteArray array = file.readAll();
             int length = array.size();
             unsigned char* data = reinterpret_cast<unsigned char*>(&array.data()[0]);

--- a/libqnanopainter/qnanoimage.h
+++ b/libqnanopainter/qnanoimage.h
@@ -27,6 +27,7 @@
 #include <QString>
 #include <QOpenGLFramebufferObject>
 #include <QDebug>
+#include <QImage>
 
 class QNanoPainter;
 
@@ -51,6 +52,9 @@ public:
     // Constructs an image with the filename and flags
     QNanoImage(const QString &filename, ImageFlags flags = {});
 
+    // Constructs an image from QImage with the filename and flags
+    QNanoImage(QImage image, const QString &filename, ImageFlags flags = {});
+
     // Set the filename of the image
     void setFilename(const QString &filename);
 
@@ -64,6 +68,7 @@ public:
     int height() const;
 
     static QNanoImage fromFrameBuffer(const QOpenGLFramebufferObject *fbo, ImageFlags flags = QNanoImage::FLIPY);
+    static QNanoImage fromCache(QNanoPainter *painter, const QString &filename, ImageFlags flags = {});
 
 private:
     friend class QNanoPainter;
@@ -77,11 +82,12 @@ private:
 
     void updateUniqueKey();
 
-    QNanoPainter *m_parentPainter;
+    QNanoPainter *m_parentPainter = nullptr;
     QSharedPointer<QNanoDataElement> m_imageData;
+    std::unique_ptr<QImage> m_image;
     QString m_filename;
     GLuint m_textureId = 0;
-    QNanoImage::ImageFlags m_flags;
+    QNanoImage::ImageFlags m_flags = {};
     QString m_uniqueKey;
 
 };

--- a/libqnanopainter/qnanoimage.h
+++ b/libqnanopainter/qnanoimage.h
@@ -78,7 +78,7 @@ private:
     void updateUniqueKey();
 
     QNanoPainter *m_parentPainter;
-    QNanoDataElement *m_imageData;
+    QSharedPointer<QNanoDataElement> m_imageData;
     QString m_filename;
     GLuint m_textureId = 0;
     QNanoImage::ImageFlags m_flags;

--- a/libqnanopainter/qnanopainter.cpp
+++ b/libqnanopainter/qnanopainter.cpp
@@ -173,7 +173,7 @@ QNanoPainter::~QNanoPainter()
         m_backend->nvgDelete(m_nvgContext);
     }
 
-    qDeleteAll(m_dataCache);
+    m_dataCache.clear();
 }
 
 /*!

--- a/libqnanopainter/qnanopainter.h
+++ b/libqnanopainter/qnanopainter.h
@@ -277,7 +277,7 @@ private:
     void _checkAlignPixelsAdjustOne(float *a);
 
     // TODO: Consider implementing QNanoDataCache class with methods instead of this
-    QHash<QString, QNanoDataElement*> m_dataCache;
+    QHash<QString, QSharedPointer<QNanoDataElement>> m_dataCache;
 
     NVGcontext* m_nvgContext;
     QScopedPointer<QNanoBackend> m_backend;


### PR DESCRIPTION
- Fix memory leak in cache handling.
- Add new QImage based overload for QNanoImage.
- Add new static function QNanoImage::fromCache to allow fetching
  previously created QImage from cache.
- The QImage will be automatically converted to RGBA8888 format.