### PR TITLE
Fix invalid version check

### DIFF
--- a/libqnanopainter/qnanoquickitem.h
+++ b/libqnanopainter/qnanoquickitem.h
@@ -144,7 +144,7 @@ private:
     int m_textureHeight;
 };
 
-#if QT_VERSION >= 0x051000  // Qt 5.10 and later
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #  define QNANO_QUICKITEM_UPDATE QMetaObject::invokeMethod(this, &QNanoQuickItem::update);
 #else
 #  define QNANO_QUICKITEM_UPDATE QMetaObject::invokeMethod(this, "update");


### PR DESCRIPTION
QT_VERSION is (major << 16) + (minor << 8) + patch. So for Qt 5.10 this gave (5 << 16) + (10 << 8) + 0 which is 0x050A00, not 0x051000 as we're in hex :)