### PR TITLE
Add C++99 {} initializers to some variables to prevent valgrind-memcheck uninitialized variable complaints 

### DIFF
--- a/examples/gallery/qnanopainter_features/src/galleryitem.h
+++ b/examples/gallery/qnanopainter_features/src/galleryitem.h
@@ -47,8 +47,8 @@ Q_SIGNALS:
     void animationSineChanged();
 
 private:
-    float m_animationTime;
-    float m_animationSine;
+    float m_animationTime {};
+    float m_animationSine {};
 };
 
 #endif // GALLERYITEM_H

--- a/examples/gallery/qnanopainter_features/src/galleryitempainter.h
+++ b/examples/gallery/qnanopainter_features/src/galleryitempainter.h
@@ -52,9 +52,9 @@ private:
     void drawRect(float x, float y, float w, float h);
 
     //QNanoPainter *m_painter;
-    float m_animationTime;
-    float m_animationSine;
-    int m_viewIndex;
+    float m_animationTime {};
+    float m_animationSine {};
+    int m_viewIndex {};
 
     QNanoImage m_testImage;
     QNanoImage m_patternImage;

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitem.h
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitem.h
@@ -52,9 +52,9 @@ Q_SIGNALS:
     void testCountChanged();
 
 private:
-    float m_animationTime;
-    int m_enabledTests;
-    int m_testCount;
+    float m_animationTime {};
+    int m_enabledTests {};
+    int m_testCount {};
 };
 
 #endif // DEMOQNANOITEM_H

--- a/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.h
+++ b/examples/qnanopainter_vs_qpainter_demo/src/demoqnanoitempainter.h
@@ -24,9 +24,9 @@ private:
     float _flowerPos(int i);
 
     QNanoPainter *m_painter;
-    float m_animationTime;
-    int m_enabledTests;
-    int m_testCount;
+    float m_animationTime {};
+    int m_enabledTests {};
+    int m_testCount {};
 
     // Colors
     QNanoColor m_colorWhite, m_colorGray, m_colorBlack,

--- a/libqnanopainter/qnanoquickitem.h
+++ b/libqnanopainter/qnanoquickitem.h
@@ -165,6 +165,6 @@ public Q_SLOTS: \
         QNANO_QUICKITEM_UPDATE \
     } \
 private: \
-    type variable;
+    type variable {};
 
 #endif // QNANOQUICKITEM_H


### PR DESCRIPTION
Running valgrind from QtCreator, one notes a long list of "uninitialized variable" complaints. These are mostly suppressed by this PR which adds "{}" initializers to the specific variable declarations that are the source of such warnings. 

See the attached files "qnanopainter.memcheck-<programname>" which show the original valgrind output without these fixes:

[qnanopainter.memcheck-gallery.txt](https://github.com/QUItCoding/qnanopainter/files/11537248/qnanopainter.memcheck-gallery.txt)
[qnanopainter.memcheck-helloitem.txt](https://github.com/QUItCoding/qnanopainter/files/11537249/qnanopainter.memcheck-helloitem.txt)
[qnanopainter.memcheck-hellowidget.txt](https://github.com/QUItCoding/qnanopainter/files/11537250/qnanopainter.memcheck-hellowidget.txt)
[qnanopainter.memcheck-qnanopainter_vs_qpainter_demo.txt](https://github.com/QUItCoding/qnanopainter/files/11537251/qnanopainter.memcheck-qnanopainter_vs_qpainter_demo.txt)

See the attached files "qnanopainter.memcheck-<programname>-after-fix" to see the valgrind output after this PR is applied:

[qnanopainter.memcheck-gallery-after-fix.txt](https://github.com/QUItCoding/qnanopainter/files/11537252/qnanopainter.memcheck-gallery-after-fix.txt)
[qnanopainter.memcheck-hellowindow-after-fix.txt](https://github.com/QUItCoding/qnanopainter/files/11537253/qnanopainter.memcheck-hellowindow-after-fix.txt)
[qnanopainter.memcheck-qnanopainter_vs_qpainter_demo-after-fix.txt](https://github.com/QUItCoding/qnanopainter/files/11537254/qnanopainter.memcheck-qnanopainter_vs_qpainter_demo-after-fix.txt)


