### PR TITLE
Fix QNanoWidget OpenGL context usage

### DIFF
--- a/examples/gallery/main.cpp
+++ b/examples/gallery/main.cpp
@@ -10,6 +10,8 @@ int main(int argc, char *argv[])
     // load res from libqnanopainter
     Q_INIT_RESOURCE(libqnanopainterdata);
 
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
 #ifdef Q_OS_WIN
     // Select between OpenGL and OpenGL ES (Angle)
     //QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/examples/helloitem/main.cpp
+++ b/examples/helloitem/main.cpp
@@ -8,6 +8,8 @@ int main(int argc, char *argv[])
     // load res from libqnanopainter
     Q_INIT_RESOURCE(libqnanopainterdata);
 
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
 #ifdef Q_OS_WIN
     // Select between OpenGL and OpenGL ES (Angle)
     //QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/examples/hellowidget/main.cpp
+++ b/examples/hellowidget/main.cpp
@@ -27,6 +27,8 @@ int main(int argc, char *argv[])
     // load res from libqnanopainter
     Q_INIT_RESOURCE(libqnanopainterdata);
 
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
 #ifdef Q_OS_WIN
     // Select between OpenGL and OpenGL ES (Angle)
     //QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/examples/hellowindow/main.cpp
+++ b/examples/hellowindow/main.cpp
@@ -27,6 +27,8 @@ int main(int argc, char *argv[])
     // load res from libqnanopainter
     Q_INIT_RESOURCE(libqnanopainterdata);
 
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
 #ifdef Q_OS_WIN
     // Select between OpenGL and OpenGL ES (Angle)
     //QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/examples/qnanopainter_vs_qpainter_demo/main.cpp
+++ b/examples/qnanopainter_vs_qpainter_demo/main.cpp
@@ -13,6 +13,8 @@ int main(int argc, char *argv[])
     // load res from libqnanopainter
     Q_INIT_RESOURCE(libqnanopainterdata);
 
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
 #ifdef Q_OS_WIN
     // Select between OpenGL and OpenGL ES (Angle)
     //QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/libqnanopainter/qnanopainter.h
+++ b/libqnanopainter/qnanopainter.h
@@ -27,6 +27,8 @@
 #include <QTransform>
 #include <QSharedPointer>
 #include <QSurfaceFormat>
+#include <QOpenGLContext>
+#include <QOffscreenSurface>
 #include "qnanocolor.h"
 #include "private/qnanobrush.h"
 #include "private/qnanodataelement.h"
@@ -299,6 +301,10 @@ private:
     QSharedPointer<QNanoFont> m_defaultFont;
     QString m_openglContextName;
 
+#ifndef QNANO_USE_RHI
+    QOpenGLContext m_openglContext;
+    QOffscreenSurface m_openglSurface;
+#endif
 };
 
 #endif // QNANOPAINTER_H


### PR DESCRIPTION
When using multiple QNanoWidgets, each widget will get a unique instance of a QOpenGLContext object. When the global instance of QNanoPainter is initialised, it happens against the OpenGL context owned by one of the QNanoWidgets (which ever is painted first).

This means that the global instance of QNanoPainter may not work correctly when used with other QNanoWidget instances. There are 2 things needed to fix this:

- The app must enable the Qt::AA_ShareOpenGLContexts attribute. This allows the QNanoPainter to be initialised against one QOpenGLContext, but also used with other QOpenGLContexts.

- The QNanoPainter should be initialised against the global shared QOpenGLContext that Qt maintains. This is because, on Windows, the QNanoPainter backend retrieves the OpenGL function pointers from the active QOpenGLContext, but then uses them as a global variable. This means that once that particular QOpenGLContext is destroyed (ie. the QNanoWidget is destroyed), the OpenGL function pointers are also destroyed, but the global QNanoPainter backend still continues to reference them.